### PR TITLE
US016: added status obras cache config directory

### DIFF
--- a/mserv_obras/dal/cache/__init__.py
+++ b/mserv_obras/dal/cache/__init__.py
@@ -1,1 +1,2 @@
 from .geographical import DistState
+from .ostatus import OStatus

--- a/mserv_obras/dal/cache/geographical.py
+++ b/mserv_obras/dal/cache/geographical.py
@@ -16,18 +16,18 @@ class DistState(dal.ADBCache):
     def __init__(self):
         super().__init__()
 
-    def __packer(self, l):
+    def _packer(self, l):
         k, v = l.strip().split(self._SPLIT_CHAR)
         return (k, v)
 
     def _load(self, origins):
         """
         """
-        self.__expectations(origins)
+        self._expectations(origins)
         with open(origins[self._IDX_ORIGIN], 'r') as s:
-            self.data = dict(map(self.__packer, s.readlines()))
+            self.data = dict(map(self._packer, s.readlines()))
 
-    def __expectations(self, origins):
+    def _expectations(self, origins):
         """
         """
         if len(origins) == self._EXPECTED_ORIGINS:

--- a/mserv_obras/dal/cache/ostatus.py
+++ b/mserv_obras/dal/cache/ostatus.py
@@ -1,0 +1,10 @@
+import dal
+from .geographical import DistState
+
+
+@dal.authoritative('obra_status')
+class OStatus(DistState):
+    """
+    """
+    def __init__(self):
+        super().__init__()

--- a/resources/cache/geographical/config.yml
+++ b/resources/cache/geographical/config.yml
@@ -1,4 +1,4 @@
-name: dist_estado
+name: distribución municipal de el estado
 origins:
   - nl.1549833345
 author: wiseguy

--- a/resources/cache/obra_status/status.1549833346
+++ b/resources/cache/obra_status/status.1549833346
@@ -1,0 +1,3 @@
+1;Estado uno
+2;Estado dos
+3;Estado tres


### PR DESCRIPTION
The cache of status obras is ready to get used.

In Fact, we also added an authoritative cache class
into dal.cache package of obras microservice to deal with.

In the spirit of not putting this user story off for a long time,
The current types of obra are just fake until the scrum master
shows up and feed the definitive ones.

Signed-off-by: Bob Ross <pianodaemon@gmail.com>